### PR TITLE
Standardize branding to lowercase **randomforge** across docs and

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Initial Public Release
 
 This is the first publicly available version of **randomforge**, released as an
-early-stage foundation for the emerging *RandomForge* ecosystem
+early-stage foundation for the emerging **randomforge** ecosystem
 ("Innovating the Future of Randomization").
 
 The 0.1.0 release focuses on establishing the architectural core and enabling

--- a/R/pkgname.R
+++ b/R/pkgname.R
@@ -33,7 +33,7 @@
 #' The package aims to support a broad range of classical, 
 #' covariate-adaptive, and response-adaptive techniques while 
 #' enabling reproducibility, auditability, and methodological clarity.
-#' Built as part of the open RandomForge initiative ("Innovating the 
+#' Built as part of the open *randomforge* initiative ("Innovating the 
 #' Future of Randomization"), the package encourages community 
 #' collaboration, modular extensions, and contributions from academia, 
 #' industry, and clinical researchers.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # randomforge
 
-**RandomForge — Innovating the Future of Randomization**
+**randomforge — Innovating the Future of Randomization**
 
 `randomforge` is an open, extensible framework for clinical trial
 randomization methods in R.  
@@ -9,7 +9,7 @@ randomization procedures, starting with a flexible implementation of
 **permuted block randomization** and designed to grow into a broader ecosystem
 of randomization methods.
 
-This package is the core engine of the wider **RandomForge** initiative:
+This package is the core engine of the wider **randomforge** initiative:
 a community-driven effort to innovate the future of clinical trial
 randomization.
 
@@ -23,7 +23,7 @@ Yet many tools currently in use are:
 - opaque in how assignments are generated,
 - and not designed for collaborative innovation.
 
-**RandomForge** aims to change this by providing an open, shared infrastructure
+**randomforge** aims to change this by providing an open, shared infrastructure
 for randomization methods – where ideas can grow into trusted, well-documented
 and practically usable methods, developed together by the community.
 
@@ -62,7 +62,7 @@ response-adaptive procedures).
 ## 🚀 Planned Extensions
 
 While the current release focuses on permuted block randomization, the
-RandomForge initiative is designed to cover a much wider range of techniques
+**randomforge** initiative is designed to cover a much wider range of techniques
 over time, including (but not limited to):
 
 - baseline-adaptive and covariate-adaptive methods (e.g. minimization),

--- a/vignettes/randomforge_contribution.Rmd
+++ b/vignettes/randomforge_contribution.Rmd
@@ -16,9 +16,9 @@ knitr::opts_chunk$set(
 )
 ```
 
-# Introduction
+## Introduction
 
-**RandomForge — An Open Project for Clinical Trial Randomization in R**
+**randomforge — An Open Project for Clinical Trial Randomization in R**
 
 `randomforge` is a newly started, open-source project on GitHub that aims to
 provide a clean and transparent implementation of clinical trial randomization
@@ -38,7 +38,7 @@ This vignette explains how to:
 3. Use GitHub effectively even if you are new to it  
 
 
-# 1. Installing randomforge and running a simple randomization
+## Installing randomforge and running a simple randomization
 
 At this stage, the package is not yet on CRAN.  
 You can install the development version directly from GitHub:
@@ -78,8 +78,7 @@ blockSizes <- getBlockSizes(config$treatmentArmIds, 8)
 
 # Create a permuted block randomization method
 randomMethodPBR <- getRandomMethodPBR(
-    blockSizes              = blockSizes,
-    fixedBlockDesignEnabled = FALSE
+    blockSizes = blockSizes
 )
 
 # Create a random allocation value service
@@ -88,12 +87,12 @@ ravService$createNewRandomAllocationValues(config)
 
 # Create a few randomization results
 resultList <- lapply(1:8, function(i) {
-    getNextRandomResult(
+    suppressMessages(getNextRandomResult(
         randomDataBase               = randomDataBase,
         randomProject                = randomProject,
         randomMethod                 = randomMethodPBR,
         randomAllocationValueService = ravService
-    )
+    ))
 })
 
 # Convert results to a data frame
@@ -102,7 +101,7 @@ randomDataBase |>
     knitr::kable()
 ```
 
-# 2. How to contribute to randomforge
+## How to contribute to randomforge
 
 Contributions of all kinds are welcome:
 
@@ -118,7 +117,7 @@ get involved.
 We are happy to support new contributors.
 
 
-# 3. Option A: Get invited as a direct contributor
+### Option A: Get invited as a direct contributor
 
 If you prefer not to deal with forks or pull requests, you can simply request
 to be added as a contributor to the GitHub repository.
@@ -137,24 +136,24 @@ Once added, you will be able to push branches and open pull requests directly
 in the main repository.
 
 
-# 4. Option B: Contribute via Fork (recommended for most users)
+### Option B: Contribute via Fork (recommended for most users)
 
 If you are not familiar with GitHub contribution workflows, here is a simple
 step-by-step guide.
 
-## Step 1 — Create a GitHub account  
+#### Step 1 — Create a GitHub account  
 If you do not already have one, register at  
 https://github.com
 
-## Step 2 — Open the randomforge repository  
+#### Step 2 — Open the randomforge repository  
 Navigate to:  
 https://github.com/RCONIS/randomforge
 
-## Step 3 — Click “Fork”  
+#### Step 3 — Click “Fork”  
 The button is in the upper-right corner.  
 This creates *your own copy* of the repository under your GitHub account.
 
-## Step 4 — Clone your fork to your local machine
+#### Step 4 — Clone your fork to your local machine
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/randomforge.git
@@ -166,29 +165,29 @@ Then:
 cd randomforge
 ```
 
-## Step 5 — Create a new branch for your change
+#### Step 5 — Create a new branch for your change
 
 ```bash
 git checkout -b my-feature-branch
 ```
 
-## Step 6 — Make your changes locally  
+#### Step 6 — Make your changes locally  
 Edit R files, documentation, tests, examples, or vignettes.
 
-## Step 7 — Commit your changes
+#### Step 7 — Commit your changes
 
 ```bash
 git add .
 git commit -m "Add new feature / fix / improvement"
 ```
 
-## Step 8 — Push your branch to your fork
+#### Step 8 — Push your branch to your fork
 
 ```bash
 git push origin my-feature-branch
 ```
 
-## Step 9 — Open a Pull Request  
+#### Step 9 — Open a Pull Request  
 Go back to your fork on GitHub and click:
 
 **“Compare & pull request”**
@@ -202,7 +201,7 @@ In the Pull Request description, please provide:
 We will review all contributions as soon as possible.
 
 
-# 5. Getting help
+## Getting help
 
 If you get stuck at any point — GitHub workflow, code questions, architecture
 discussion — feel free to:
@@ -214,8 +213,8 @@ All questions are welcome, especially from newcomers.
 We want to make contributing as easy and friendly as possible.
 
 
-# 6. Thank you
+## Thank you
 
-We appreciate your interest in contributing to the RandomForge project.  
+We appreciate your interest in contributing to the *randomforge* project.  
 Your ideas and contributions help shape a more open, transparent, and
 community-driven future for clinical trial randomization in R.

--- a/vignettes/randomforge_getting_started.Rmd
+++ b/vignettes/randomforge_getting_started.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# Introduction
+## Introduction
 
 `randomforge` is an open-source R package providing a transparent and modular 
 framework for clinical trial randomization.  
@@ -28,7 +28,7 @@ If you are new to randomization frameworks or want a minimal working example,
 this is a good place to start.
 
 
-# Installation
+## Installation
 
 At this stage, `randomforge` is available only on GitHub:
 
@@ -38,7 +38,7 @@ At this stage, `randomforge` is available only on GitHub:
 remotes::install_github("RCONIS/randomforge")
 ```
 
-# Creating a Randomization Project
+## Creating a Randomization Project
 
 Every workflow begins with a `RandomProject` stored inside an in-memory 
 `RandomDataBase`:
@@ -59,7 +59,7 @@ randomDataBase$persist(randomProject)
 A project groups all configurations, subjects, and resulting allocations.
 
 
-# Defining a Randomization Configuration
+## Defining a Randomization Configuration
 
 A configuration defines:
 
@@ -86,7 +86,7 @@ randomDataBase$persist(config)
 ```
 
 
-# Creating a Block Randomization Method
+## Creating a Block Randomization Method
 
 `randomforge` currently supports **permuted block randomization** (PBR) as a 
 fully working implementation.
@@ -108,7 +108,7 @@ randomMethodPBR <- getRandomMethodPBR(
 )
 ```
 
-# Create a Random Allocation Value Service
+## Create a Random Allocation Value Service
 
 ```{r}
 # Create a random allocation value service
@@ -125,7 +125,7 @@ ravService |>
 
 Other key performance indicators are planned for future releases.
 
-# Running Randomization
+## Running Randomization
 
 To generate assignments, create a random allocation value service, then call 
 `getNextRandomResult()`.
@@ -147,7 +147,7 @@ ravService |>
     plot()
 ```
 
-# Inspecting the Results
+## Inspecting the Results
 
 All subjects and allocations stored in the database can be displayed as a data
 frame:
@@ -168,7 +168,7 @@ resultData |>
     knitr::kable()
 ```
 
-# Exporting to Excel (Optional)
+## Exporting to Excel (Optional)
 
 `randomforge` supports exporting subject lists or randomization results via 
 `writeExcelFile()`:
@@ -179,7 +179,7 @@ writeExcelFile(resultData, "randomization_list.xlsx")
 ```
 
 
-# What’s Next?
+## What’s Next?
 
 The project is in an early phase, and many extensions are planned:
 
@@ -194,7 +194,7 @@ To learn how to contribute, see the vignette:
 **`vignette("randomforge_contribution")`**
 
 
-# Thank You
+## Thank You
 
 We hope this vignette helps you get started with `randomforge`.  
 Feedback and suggestions are very welcome via GitHub issues.


### PR DESCRIPTION
vignettes

- Updated all references from RandomForge to **randomforge**
- Improved consistency in documentation and markdown files
- Adjusted vignette headings to use appropriate markdown levels
- Simplified example code for block randomization method usage
- Enhanced clarity in contribution and getting started guides
- Fixed minor formatting issues in vignettes